### PR TITLE
Run formatter on mcp.md docs

### DIFF
--- a/docs/groovy/how-to-guides/mcp.md
+++ b/docs/groovy/how-to-guides/mcp.md
@@ -214,8 +214,8 @@ If that works, you're all set! Try Deephaven MCP for:
 
 The following parameters are available for the systems server:
 
-| Field                | Type    | Required When | Description                                                                                                          |
-| -------------------- | ------- | ------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Field                | Type    | Required When | Description                                                                                                           |
+| -------------------- | ------- | ------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `host`               | string  | Optional      | Hostname or IP address of the Deephaven Community Core session (e.g., `"localhost"`).                                 |
 | `port`               | integer | Optional      | Port number for the session connection (e.g., `10000`).                                                               |
 | `auth_type`          | string  | Optional      | Authentication type: `"Anonymous"` (default), `"Basic"`, or custom authenticator strings.                             |

--- a/docs/python/how-to-guides/mcp.md
+++ b/docs/python/how-to-guides/mcp.md
@@ -214,8 +214,8 @@ If that works, you're all set! Try Deephaven MCP for:
 
 The following parameters are available for the systems server:
 
-| Field                | Type    | Required When | Description                                                                                                          |
-| -------------------- | ------- | ------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Field                | Type    | Required When | Description                                                                                                           |
+| -------------------- | ------- | ------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `host`               | string  | Optional      | Hostname or IP address of the Deephaven Community Core session (e.g., `"localhost"`).                                 |
 | `port`               | integer | Optional      | Port number for the session connection (e.g., `10000`).                                                               |
 | `auth_type`          | string  | Optional      | Authentication type: `"Anonymous"` (default), `"Basic"`, or custom authenticator strings.                             |


### PR DESCRIPTION
This PR applies formatting changes to the MCP documentation files using the docs/format tool. This should be merged into the jj-858-mcp branch to update PR #7267.